### PR TITLE
Switch set difference from groovy `-` to Set.removeAll

### DIFF
--- a/src/groovy/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzModule.groovy
@@ -238,7 +238,9 @@ class SnpLzModule extends AbstractHighDimensionDataTypeModule {
         }
 
         // have we found the positions for all the assays?
-        def assaysNotFound = (assays as Set) - foundAssays
+        // The groovy '-' default method uses a quadratic algorithm which is too slow here, so use the Java method
+        def assaysNotFound = assays as Set
+        assaysNotFound.removeAll(foundAssays)
         if (assaysNotFound) {
             throw new UnexpectedResultException(
                     "Could not find the blob position for " +


### PR DESCRIPTION
This difference check verifies if all expected assay values are present
in the database. The original code uses the groovy minus operator, which
uses a quadratic algorithm even if both operands are sets. In datasets
with several thousand assays it can take several seconds to evaluate
this, at least when running in debug mode. The alternative of using
Set.removeAll runs instantly.
