### PR TITLE
Changed test data generation for SNP data.

### DIFF
--- a/grails-app/domain/org/transmartproject/db/dataquery/highdim/snp_lz/DeSnpInfo.groovy
+++ b/grails-app/domain/org/transmartproject/db/dataquery/highdim/snp_lz/DeSnpInfo.groovy
@@ -4,7 +4,7 @@ class DeSnpInfo {
 
     String name
     String chromosome
-    Integer pos
+    Long pos
 
     static mapping = {
         table      schema: 'deapp',       name:      'de_snp_info'

--- a/grails-app/domain/org/transmartproject/db/dataquery/highdim/snp_lz/GenotypeProbeAnnotation.groovy
+++ b/grails-app/domain/org/transmartproject/db/dataquery/highdim/snp_lz/GenotypeProbeAnnotation.groovy
@@ -25,7 +25,7 @@ class GenotypeProbeAnnotation {
 
     String snpName
     String chromosome
-    BigDecimal pos
+    Long pos
     String ref
     String alt
     String geneInfo

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/HighDimensionResourceService.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/HighDimensionResourceService.groovy
@@ -37,6 +37,7 @@ class HighDimensionResourceService implements HighDimensionResource {
 
     private static final int MAX_CACHED_DATA_TYPE_RESOURCES = 50
     private static final int MAX_CACHED_PLATFORM_MAPPINGS = 200
+    private static final int ASSAY_FETCH_SIZE = 5000
 
     /*
      * I couldn't get this field autowired with this class in
@@ -87,6 +88,8 @@ class HighDimensionResourceService implements HighDimensionResource {
             isNotNull 'platform'
 
             join 'patient'
+
+            fetchSize ASSAY_FETCH_SIZE
         } /* one row per assay */
 
         HashMultimap multiMap = HashMultimap.create()

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzAllDataProjection.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzAllDataProjection.groovy
@@ -20,7 +20,6 @@
 package org.transmartproject.db.dataquery.highdim.snp_lz
 
 import org.transmartproject.core.dataquery.highdim.projections.AllDataProjection
-import org.transmartproject.db.dataquery.highdim.projections.AllDataProjectionImpl
 
 /**
  * Implements {@link AllDataProjection} for the snp_lz module.
@@ -36,10 +35,10 @@ class SnpLzAllDataProjection implements AllDataProjection {
             .collectEntries { [it.name, it.type] }
 
     final Map<String, Class> rowProperties =
-            ['snpName', 'a1', 'a2', 'imputeQuality', 'GTProbabilityThreshold',
+            ['snpName', 'chromosome', 'position', 'a1', 'a2', 'imputeQuality', 'GTProbabilityThreshold',
              'minorAlleleFrequency', 'minorAllele', 'a1a1Count', 'a1a2Count',
              'a2a2Count', 'noCallCount'].collectEntries {
-                def p = SnpLzCell.metaClass.getProperty(it)
+                def p = SnpLzRow.metaClass.getProperty(it)
                 [p.name, p.type]
             }
 

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzModule.groovy
@@ -99,10 +99,10 @@ class SnpLzModule extends AbstractHighDimensionDataTypeModule {
     @Override
     protected List<DataRetrievalParameterFactory> createDataConstraintFactories() {
         chromosomeSegmentConstraintFactory.with {
-            segmentPrefix      = 'ann.'
+            segmentPrefix      = 'snpInfo.'
             segmentStartColumn = 'pos'
             segmentEndColumn   = 'pos'
-            forceBigDecimal    = true
+            forceBigDecimal    = false
         }
 
         [standardDataConstraintFactory,

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzRow.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzRow.groovy
@@ -150,8 +150,8 @@ class SnpLzRow implements BioMarkerDataRow<SnpLzCell> {
         (String) probeData.chromosome
     }
 
-    Integer getPosition() {
-        (Integer) probeData.position
+    Long getPosition() {
+        (Long) probeData.position
     }
 
     String getSnpName() {

--- a/transmart-core-db-tests/src/groovy/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzTestData.groovy
+++ b/transmart-core-db-tests/src/groovy/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzTestData.groovy
@@ -218,6 +218,16 @@ class SnpLzTestData {
                         it.chromosome == annotation.chromosome }
             assert snpInfo != null
 
+            // Choose value of minorAllele based on the allele count, to vary its
+            // value: to generate test cases for both 'A1' and 'A2'.
+            long a1Count = 0
+            long a2Count = 0
+            gtss.each {
+                a1Count += it.count( a1 )
+                a2Count += it.count( a2 )
+            }
+            def minorAllele = (a1Count <= a2Count) ? 'A1' : 'A2'
+
             def r = new SnpDataByProbeCoreDb(
                     trialName: TRIAL_NAME,
                     a1: a1,
@@ -225,7 +235,7 @@ class SnpLzTestData {
                     gtProbabilityThreshold: 1.0,
                     imputeQuality: 0.1 * id,
                     maf: 0.218605627887442,
-                    minorAllele: 'A1',
+                    minorAllele: minorAllele,
                     CA1A1: gtss.count { "$a1 $a1" },
                     CA1A2: gtss.count { "$a1 $a2" } + gtss.count { "$a2 $a1" },
                     CA2A2: gtss.count { "$a2 $a2" },


### PR DESCRIPTION
Vary the value of minorAllele in SnpDataByProbeCoreDb. This
would detect a previously undetected bug in SnpLzRow
(fixed in d178a3e6d0056492cf94cb1e9ed66dcf472a8656).
