### PR TITLE
Issues/snp likely genotype

### DIFF
--- a/src/groovy/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzAllDataProjection.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzAllDataProjection.groovy
@@ -33,7 +33,7 @@ class SnpLzAllDataProjection implements AllDataProjection {
             .metaClass
             .properties
             // The likelyAlleles are already covered in the likelyGenotype property, no need to include them twice
-            .findAll { !(it.name in ['class', 'likelyAllele1', 'likelyAllele1']) }
+            .findAll { !(it.name in ['class', 'likelyAllele1', 'likelyAllele2']) }
             .collectEntries { [it.name, it.type] }
 
     final Map<String, Class> rowProperties =

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzAllDataProjection.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzAllDataProjection.groovy
@@ -32,7 +32,8 @@ class SnpLzAllDataProjection implements AllDataProjection {
     final Map<String, Class> dataProperties = SnpLzCell
             .metaClass
             .properties
-            .findAll { it.name != 'class' }
+            // The likelyAlleles are already covered in the likelyGenotype property, no need to include them twice
+            .findAll { !(it.name in ['class', 'likelyAllele1', 'likelyAllele1']) }
             .collectEntries { [it.name, it.type] }
 
     final Map<String, Class> rowProperties =

--- a/src/java/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzCell.java
+++ b/src/java/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzCell.java
@@ -70,6 +70,8 @@ public final class SnpLzCell {
         return likelyAllele2;
     }
 
+    public String getLikelyGenotype() { return likelyAllele1 + "_" + likelyAllele2; }
+
     public double getMinorAlleleDose() {
         return minorAlleleDose;
     }

--- a/transmart-core-db-tests/test/integration/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzEndToEndRetrievalTest.groovy
+++ b/transmart-core-db-tests/test/integration/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzEndToEndRetrievalTest.groovy
@@ -164,6 +164,7 @@ class SnpLzEndToEndRetrievalTest {
 
                                                 hasProperty('likelyAllele1', is(gts[0] as char)),
                                                 hasProperty('likelyAllele2', is(gts[1] as char)),
+                                                hasProperty('likelyGenotype', is("${gts[0]}_${gts[1]}")),
 
                                                 hasProperty('minorAlleleDose', closeTo(doses as Double, DELTA)),
                                         )


### PR DESCRIPTION
Per issue #NAA-51

likelyAllele{1,2} are still present in the SnpLzCells, but no longer advertised by the projection so they are not exported in the rest api.
