### PR TITLE
Export/process SnpLz cell properties in a logical order

### DIFF
--- a/src/groovy/org/transmartproject/db/dataquery/highdim/AbstractHighDimensionDataTypeModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/AbstractHighDimensionDataTypeModule.groovy
@@ -19,6 +19,7 @@
 
 package org.transmartproject.db.dataquery.highdim
 
+import com.google.common.collect.ImmutableMap
 import grails.orm.HibernateCriteriaBuilder
 
 import javax.annotation.PostConstruct
@@ -50,11 +51,11 @@ abstract class AbstractHighDimensionDataTypeModule implements HighDimensionDataT
     @Autowired
     HighDimensionResourceService highDimensionResourceService
 
-    static Map<String, Class> typesMap(Class domainClass, List<String> fields,
+    static ImmutableMap<String, Class> typesMap(Class domainClass, List<String> fields,
                                        Map<String, String> translationMap = [:]) {
-        fields.collectEntries({
+        ImmutableMap.<String, Class>copyOf(fields.collectEntries({
             [(it): domainClass.metaClass.getMetaProperty(translationMap.get(it, it)).type]
-        }).asImmutable()
+        }))
     }
 
     @PostConstruct

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/HighDimensionResourceService.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/HighDimensionResourceService.groovy
@@ -49,7 +49,7 @@ class HighDimensionResourceService implements HighDimensionResource {
      * findAutowiringMetadata(String beanName, Class<?> clazz) is called with
      * '(inner bean)', ConceptsResourceService as parameters, and then does a
      * lookup on a cache whose key is preferably the bean name.
-     * Only if the bean name is empty does it use the class name, excpet the
+     * Only if the bean name is empty does it use the class name, except the
      * the bean name is '(inner bean)', which I'm guessing is used with other
      * inner beans.
      */

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/acgh/AcghModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/acgh/AcghModule.groovy
@@ -19,6 +19,7 @@
 
 package org.transmartproject.db.dataquery.highdim.acgh
 
+import com.google.common.collect.ImmutableMap
 import grails.orm.HibernateCriteriaBuilder
 import org.hibernate.ScrollableResults
 import org.hibernate.engine.SessionImplementor
@@ -53,11 +54,11 @@ class AcghModule extends AbstractHighDimensionDataTypeModule {
 
     final String description = "ACGH data"
 
-    final Map<String, Class> dataProperties = typesMap(DeSubjectAcghData,
+    final ImmutableMap<String, Class> dataProperties = typesMap(DeSubjectAcghData,
             ['chipCopyNumberValue', 'segmentCopyNumberValue', 'flag',
              'probabilityOfLoss', 'probabilityOfNormal', 'probabilityOfGain', 'probabilityOfAmplification'])
 
-    final Map<String, Class> rowProperties = typesMap(RegionRowImpl,
+    final ImmutableMap<String, Class> rowProperties = typesMap(RegionRowImpl,
             ['id', 'name', 'cytoband', 'chromosome', 'start', 'end', 'numberOfProbes', 'bioMarker'])
 
     @Autowired

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/metabolite/MetaboliteModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/metabolite/MetaboliteModule.groovy
@@ -19,6 +19,7 @@
 
 package org.transmartproject.db.dataquery.highdim.metabolite
 
+import com.google.common.collect.ImmutableMap
 import grails.orm.HibernateCriteriaBuilder
 import org.hibernate.ScrollableResults
 import org.hibernate.engine.SessionImplementor
@@ -48,10 +49,10 @@ class MetaboliteModule extends AbstractHighDimensionDataTypeModule {
 
     final String description = 'Metabolomics data (Mass Spec)'
 
-    final Map<String, Class> dataProperties = typesMap(DeSubjectMetabolomicsData,
+    final ImmutableMap<String, Class> dataProperties = typesMap(DeSubjectMetabolomicsData,
             ['rawIntensity', 'logIntensity', 'zscore'])
 
-    final Map<String, Class> rowProperties = typesMap(MetaboliteDataRow,
+    final ImmutableMap<String, Class> rowProperties = typesMap(MetaboliteDataRow,
             ['hmdbId', 'biochemicalName'])
 
     @Autowired

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/mirna/AbstractMirnaSharedModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/mirna/AbstractMirnaSharedModule.groovy
@@ -19,6 +19,7 @@
 
 package org.transmartproject.db.dataquery.highdim.mirna
 
+import com.google.common.collect.ImmutableMap
 import grails.orm.HibernateCriteriaBuilder
 import org.hibernate.ScrollableResults
 import org.hibernate.engine.SessionImplementor
@@ -45,10 +46,10 @@ import static org.hibernate.sql.JoinFragment.INNER_JOIN
 
 abstract class AbstractMirnaSharedModule extends AbstractHighDimensionDataTypeModule {
 
-    final Map<String, Class> dataProperties = typesMap(DeSubjectMirnaData,
+    final ImmutableMap<String, Class> dataProperties = typesMap(DeSubjectMirnaData,
             ['rawIntensity', 'logIntensity', 'zscore'])
 
-    final Map<String, Class> rowProperties = typesMap(MirnaProbeRow,
+    final ImmutableMap<String, Class> rowProperties = typesMap(MirnaProbeRow,
             ['probeId', 'mirnaId'])
 
     @Autowired

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/mrna/MrnaModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/mrna/MrnaModule.groovy
@@ -19,6 +19,7 @@
 
 package org.transmartproject.db.dataquery.highdim.mrna
 
+import com.google.common.collect.ImmutableMap
 import grails.orm.HibernateCriteriaBuilder
 import org.hibernate.ScrollableResults
 import org.hibernate.engine.SessionImplementor
@@ -46,10 +47,10 @@ class MrnaModule extends AbstractHighDimensionDataTypeModule {
 
     final List<String> platformMarkerTypes = ['Gene Expression']
 
-    final Map<String, Class> dataProperties = typesMap(DeSubjectMicroarrayDataCoreDb,
+    final ImmutableMap<String, Class> dataProperties = typesMap(DeSubjectMicroarrayDataCoreDb,
             ['trialName', 'rawIntensity', 'logIntensity', 'zscore'])
 
-    final Map<String, Class> rowProperties = typesMap(ProbeRow,
+    final ImmutableMap<String, Class> rowProperties = typesMap(ProbeRow,
             ['probe', 'geneId', 'geneSymbol'])
 
     @Autowired

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/parameterproducers/AllDataProjectionFactory.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/parameterproducers/AllDataProjectionFactory.groovy
@@ -19,16 +19,17 @@
 
 package org.transmartproject.db.dataquery.highdim.parameterproducers
 
+import com.google.common.collect.ImmutableMap
 import org.transmartproject.core.dataquery.highdim.projections.Projection
 import org.transmartproject.core.exceptions.InvalidArgumentsException
 import org.transmartproject.db.dataquery.highdim.projections.AllDataProjectionImpl
 
 class AllDataProjectionFactory implements DataRetrievalParameterFactory {
 
-    private Map<String, Class> dataProperties
-    private Map<String, Class> rowProperties
+    private ImmutableMap<String, Class> dataProperties
+    private ImmutableMap<String, Class> rowProperties
 
-    AllDataProjectionFactory(Map<String, Class> dataProperties, Map<String, Class> rowProperties) {
+    AllDataProjectionFactory(ImmutableMap<String, Class> dataProperties, ImmutableMap<String, Class> rowProperties) {
         this.dataProperties = dataProperties
         this.rowProperties = rowProperties
     }

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/projections/AllDataProjectionImpl.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/projections/AllDataProjectionImpl.groovy
@@ -19,6 +19,7 @@
 
 package org.transmartproject.db.dataquery.highdim.projections
 
+import com.google.common.collect.ImmutableMap
 import grails.orm.HibernateCriteriaBuilder
 import org.apache.commons.logging.Log
 import org.apache.commons.logging.LogFactory
@@ -33,10 +34,13 @@ class AllDataProjectionImpl implements CriteriaProjection<Map<String, Object>>, 
 
     static Log LOG = LogFactory.getLog(this)
 
-    Map<String, Class> dataProperties
-    Map<String, Class> rowProperties
+    // These should actually be some kind of OrderedMap that guarantees a specific iteration order, but there is no
+    // such interface in general use (only some project specific ones, e.g. org.apache.commons.collections.OrderedMap).
+    // As the next best thing we specify a concrete implementation that has stable ordering.
+    ImmutableMap<String, Class> dataProperties
+    ImmutableMap<String, Class> rowProperties
 
-    AllDataProjectionImpl(Map<String, Class> dataProperties, Map<String, Class> rowProperties) {
+    AllDataProjectionImpl(ImmutableMap<String, Class> dataProperties, ImmutableMap<String, Class> rowProperties) {
         this.dataProperties = dataProperties
         this.rowProperties = rowProperties
     }

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/protein/ProteinModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/protein/ProteinModule.groovy
@@ -19,6 +19,7 @@
 
 package org.transmartproject.db.dataquery.highdim.protein
 
+import com.google.common.collect.ImmutableMap
 import grails.orm.HibernateCriteriaBuilder
 import org.hibernate.ScrollableResults
 import org.hibernate.engine.SessionImplementor
@@ -45,10 +46,10 @@ class ProteinModule extends AbstractHighDimensionDataTypeModule {
 
     final List<String> platformMarkerTypes = ['PROTEOMICS']
 
-    final Map<String, Class> dataProperties = typesMap(DeSubjectProteinData,
+    final ImmutableMap<String, Class> dataProperties = typesMap(DeSubjectProteinData,
             ['intensity', 'logIntensity', 'zscore'])
 
-    final Map<String, Class> rowProperties = typesMap(ProteinDataRow,
+    final ImmutableMap<String, Class> rowProperties = typesMap(ProteinDataRow,
             ['uniprotName', 'peptide'])
 
     @Autowired

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/rbm/RbmModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/rbm/RbmModule.groovy
@@ -19,6 +19,7 @@
 
 package org.transmartproject.db.dataquery.highdim.rbm
 
+import com.google.common.collect.ImmutableMap
 import grails.orm.HibernateCriteriaBuilder
 import org.hibernate.ScrollableResults
 import org.hibernate.engine.SessionImplementor
@@ -46,10 +47,10 @@ class RbmModule extends AbstractHighDimensionDataTypeModule {
 
     final List<String> platformMarkerTypes = ['RBM']
 
-    final Map<String, Class> dataProperties = typesMap(DeSubjectRbmData,
+    final ImmutableMap<String, Class> dataProperties = typesMap(DeSubjectRbmData,
             ['value', 'logIntensity', 'zscore'])
 
-    final Map<String, Class> rowProperties = typesMap(RbmRow,
+    final ImmutableMap<String, Class> rowProperties = typesMap(RbmRow,
             ['antigenName', 'unit', 'uniprotName'])
 
     @Autowired

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/rnaseq/RnaSeqModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/rnaseq/RnaSeqModule.groovy
@@ -19,6 +19,7 @@
 
 package org.transmartproject.db.dataquery.highdim.rnaseq
 
+import com.google.common.collect.ImmutableMap
 import grails.orm.HibernateCriteriaBuilder
 import org.hibernate.ScrollableResults
 import org.hibernate.engine.SessionImplementor
@@ -58,10 +59,10 @@ class RnaSeqModule extends AbstractHighDimensionDataTypeModule {
 
     final String description = "Messenger RNA data (Sequencing)"
 
-    final Map<String, Class> dataProperties = typesMap(DeSubjectRnaseqData,
+    final ImmutableMap<String, Class> dataProperties = typesMap(DeSubjectRnaseqData,
             ['readcount', 'normalizedReadcount', 'logNormalizedReadcount', 'zscore'])
 
-    final Map<String, Class> rowProperties = typesMap(RegionRowImpl,
+    final ImmutableMap<String, Class> rowProperties = typesMap(RegionRowImpl,
         ['id', 'name', 'cytoband', 'chromosome', 'start', 'end', 'numberOfProbes', 'bioMarker'])
 
     @Autowired

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/rnaseqcog/RnaSeqCogModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/rnaseqcog/RnaSeqCogModule.groovy
@@ -19,6 +19,7 @@
 
 package org.transmartproject.db.dataquery.highdim.rnaseqcog
 
+import com.google.common.collect.ImmutableMap
 import grails.orm.HibernateCriteriaBuilder
 import org.hibernate.ScrollableResults
 import org.hibernate.engine.SessionImplementor
@@ -48,10 +49,10 @@ class RnaSeqCogModule extends AbstractHighDimensionDataTypeModule {
 
     final List<String> platformMarkerTypes = ['RNASEQ']
 
-    final Map<String, Class> dataProperties = typesMap(DeSubjectRnaData,
+    final ImmutableMap<String, Class> dataProperties = typesMap(DeSubjectRnaData,
             ['rawIntensity', 'logIntensity', 'zscore'])
 
-    final Map<String, Class> rowProperties = typesMap(RnaSeqCogDataRow,
+    final ImmutableMap<String, Class> rowProperties = typesMap(RnaSeqCogDataRow,
             ['annotationId', 'geneSymbol', 'geneId'])
 
     @Autowired

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzAllDataProjection.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzAllDataProjection.groovy
@@ -38,8 +38,8 @@ class SnpLzAllDataProjection implements
             ['gpsByProbeBlob', 'gtsByProbeBlob', 'doseByProbeBlob']
 
     @Override
-    Map<String, Class> getDataProperties() { _dataProperties }
-    private static final Map<String, Class> _dataProperties = ImmutableMap.copyOf(
+    ImmutableMap<String, Class> getDataProperties() { _dataProperties }
+    private static final ImmutableMap<String, Class> _dataProperties = ImmutableMap.copyOf(
             // Ensure a logical order
             ['probabilityA1A1', 'probabilityA1A2', 'probabilityA2A2', 'likelyGenotype', 'minorAlleleDose']
                     .collectEntries {
@@ -48,8 +48,8 @@ class SnpLzAllDataProjection implements
             })
 
     @Override
-    Map<String, Class> getRowProperties() { _rowProperties }
-    private static final Map<String, Class> _rowProperties = ImmutableMap.copyOf(
+    ImmutableMap<String, Class> getRowProperties() { _rowProperties }
+    private static final ImmutableMap<String, Class> _rowProperties = ImmutableMap.copyOf(
         ['snpName', 'chromosome', 'position', 'a1', 'a2', 'imputeQuality', 'GTProbabilityThreshold',
          'minorAlleleFrequency', 'minorAllele', 'a1a1Count', 'a1a2Count', 'a2a2Count', 'noCallCount'].collectEntries {
             def p = SnpLzRow.metaClass.properties.find { n -> n.name == it }

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzAllDataProjection.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzAllDataProjection.groovy
@@ -19,6 +19,7 @@
 
 package org.transmartproject.db.dataquery.highdim.snp_lz
 
+import com.google.common.collect.ImmutableMap
 import grails.orm.HibernateCriteriaBuilder
 import org.hibernate.criterion.ProjectionList
 import org.hibernate.criterion.Projections
@@ -36,19 +37,24 @@ class SnpLzAllDataProjection implements
     private static final ArrayList<String> DOMAIN_CLASS_PROPERTIES_FETCHED =
             ['gpsByProbeBlob', 'gtsByProbeBlob', 'doseByProbeBlob']
 
-    final Map<String, Class> dataProperties = SnpLzAllDataCell
-            .metaClass
-            .properties
-            .findAll { !(it.name in ['class', 'likelyAllele1', 'likelyAllele2', 'empty']) }
-            .collectEntries { [it.name, it.type] }
-
-    final Map<String, Class> rowProperties =
-            ['snpName', 'chromosome', 'position', 'a1', 'a2', 'imputeQuality', 'GTProbabilityThreshold',
-             'minorAlleleFrequency', 'minorAllele', 'a1a1Count', 'a1a2Count',
-             'a2a2Count', 'noCallCount'].collectEntries {
-                def p = SnpLzRow.metaClass.properties.find { n -> n.name == it }
+    @Override
+    Map<String, Class> getDataProperties() { _dataProperties }
+    private static final Map<String, Class> _dataProperties = ImmutableMap.copyOf(
+            // Ensure a logical order
+            ['probabilityA1A1', 'probabilityA1A2', 'probabilityA2A2', 'likelyGenotype', 'minorAlleleDose']
+                    .collectEntries {
+                def p = SnpLzAllDataCell.metaClass.properties.find { n -> n.name == it }
                 [p.name, p.type]
-            }
+            })
+
+    @Override
+    Map<String, Class> getRowProperties() { _rowProperties }
+    private static final Map<String, Class> _rowProperties = ImmutableMap.copyOf(
+        ['snpName', 'chromosome', 'position', 'a1', 'a2', 'imputeQuality', 'GTProbabilityThreshold',
+         'minorAlleleFrequency', 'minorAllele', 'a1a1Count', 'a1a2Count', 'a2a2Count', 'noCallCount'].collectEntries {
+            def p = SnpLzRow.metaClass.properties.find { n -> n.name == it }
+            [p.name, p.type]
+        })
 
     @Override
     void doWithCriteriaBuilder(HibernateCriteriaBuilder builder) {

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzModule.groovy
@@ -19,6 +19,7 @@
 
 package org.transmartproject.db.dataquery.highdim.snp_lz
 
+import com.google.common.collect.ImmutableMap
 import grails.orm.HibernateCriteriaBuilder
 import groovy.transform.CompileStatic
 import groovy.util.logging.Log4j
@@ -74,11 +75,11 @@ class SnpLzModule extends AbstractHighDimensionDataTypeModule {
 
     final List<String> platformMarkerTypes = ['SNP']
 
-    final Map<String, Class> dataProperties = typesMap(SnpLzAllDataCell,
+    final ImmutableMap<String, Class> dataProperties = typesMap(SnpLzAllDataCell,
             ['probabilityA1A1', 'probabilityA1A2', 'probabilityA2A2',
              'likelyAllele1', 'likelyAllele2', 'minorAlleleDose'])
 
-    final Map<String, Class> rowProperties = typesMap(SnpLzRow,
+    final ImmutableMap<String, Class> rowProperties = typesMap(SnpLzRow,
             ['snpName', 'chromosome', 'position', 'a1', 'a2', 'imputeQuality',
              'GTProbabilityThreshold', 'minorAlleleFrequency', 'minorAllele',
              'a1a1Count', 'a1a2Count', 'a2a2Count', 'noCallCount'])
@@ -250,8 +251,8 @@ class SnpLzModule extends AbstractHighDimensionDataTypeModule {
         }
 
         // have we found the positions for all the assays?
-        // The groovy '-' default method uses a quadratic algorithm which is too slow here, so use the Java method
         def assaysNotFound = assays as Set
+        // The groovy '-' default method uses a quadratic algorithm which is too slow here, so use the Java method
         assaysNotFound.removeAll(foundAssays)
         if (assaysNotFound) {
             throw new UnexpectedResultException(

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzProbabilitiesProjection.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzProbabilitiesProjection.groovy
@@ -20,10 +20,8 @@
 package org.transmartproject.db.dataquery.highdim.snp_lz
 
 import grails.orm.HibernateCriteriaBuilder
+import groovy.transform.Canonical
 import groovy.transform.CompileStatic
-import groovy.transform.EqualsAndHashCode
-import groovy.transform.ToString
-import groovy.transform.TupleConstructor
 import groovy.transform.TypeCheckingMode
 import org.hibernate.criterion.ProjectionList
 import org.hibernate.criterion.Projections
@@ -66,7 +64,5 @@ class SnpLzProbabilitiesProjection implements MultiValueProjection, CriteriaProj
 }
 
 @CompileStatic
-@EqualsAndHashCode
-@ToString
-@TupleConstructor
+@Canonical
 class SnpLzProbabilitiesCell {double probabilityA1A1, probabilityA1A2, probabilityA2A2}

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/vcf/VcfModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/vcf/VcfModule.groovy
@@ -19,6 +19,7 @@
 
 package org.transmartproject.db.dataquery.highdim.vcf
 
+import com.google.common.collect.ImmutableMap
 import grails.orm.HibernateCriteriaBuilder
 import org.hibernate.ScrollableResults
 import org.hibernate.engine.SessionImplementor
@@ -57,10 +58,10 @@ class VcfModule extends AbstractHighDimensionDataTypeModule {
      */
     static final String VARIANT_PROJECTION    = 'variant'
 
-    final Map<String, Class> dataProperties = typesMap(DeVariantSubjectSummaryCoreDb,
+    final ImmutableMap<String, Class> dataProperties = typesMap(DeVariantSubjectSummaryCoreDb,
     ['reference', 'variant', 'variantType'])
 
-    final Map<String, Class> rowProperties = typesMap(VcfDataRow,
+    final ImmutableMap<String, Class> rowProperties = typesMap(VcfDataRow,
     ['chromosome', 'position', 'rsId', 'referenceAllele'])
 
     @Autowired

--- a/transmart-core-db-tests/test/unit/org/transmartproject/db/dataquery/highdim/MultiValueProjectionTests.groovy
+++ b/transmart-core-db-tests/test/unit/org/transmartproject/db/dataquery/highdim/MultiValueProjectionTests.groovy
@@ -19,6 +19,7 @@
 
 package org.transmartproject.db.dataquery.highdim
 
+import com.google.common.collect.ImmutableMap
 import grails.test.mixin.TestMixin
 import grails.test.mixin.support.GrailsUnitTestMixin
 import org.junit.Test
@@ -38,8 +39,8 @@ class MultiValueProjectionTests {
 
     @Test
     void testAllDataProjectionProperties() {
-        Map<String, Class> dataProps = [foo:String, bar:Double]
-        Map<String, Class> rowProps = [rowA:Double, rowB:String]
+        ImmutableMap<String, Class> dataProps = ImmutableMap.copyOf([foo:String, bar:Double])
+        ImmutableMap<String, Class> rowProps = ImmutableMap.copyOf([rowA:Double, rowB:String])
 
         AllDataProjectionFactory factory = new AllDataProjectionFactory(dataProps, rowProps)
         AllDataProjection projection = factory.createFromParameters(Projection.ALL_DATA_PROJECTION, [:], null)

--- a/transmart-core-db-tests/test/unit/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzAllDataProjectionTests.groovy
+++ b/transmart-core-db-tests/test/unit/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzAllDataProjectionTests.groovy
@@ -1,0 +1,28 @@
+package org.transmartproject.db.dataquery.highdim.snp_lz
+
+import com.google.common.collect.ImmutableMap
+import org.junit.Test
+import org.transmartproject.core.dataquery.highdim.projections.AllDataProjection
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.contains
+import static org.hamcrest.Matchers.isA
+
+class SnpLzAllDataProjectionTests {
+
+    @Test
+    void testAllDataProjectionPropertiesOrder() {
+        AllDataProjection proj = new SnpLzAllDataProjection()
+        assertThat proj, isA(AllDataProjection)
+
+        ImmutableMap<String, Class> dataProperties = proj.dataProperties
+        ImmutableMap<String, Class> rowProperties = proj.rowProperties
+
+        // Ensure that data/rowProperties have the expected iteration order
+        assertThat dataProperties.keySet(), contains('probabilityA1A1', 'probabilityA1A2',
+                'probabilityA2A2', 'likelyGenotype', 'minorAlleleDose')
+        assertThat rowProperties.keySet(), contains('snpName', 'chromosome', 'position', 'a1', 'a2',
+                'imputeQuality', 'GTProbabilityThreshold', 'minorAlleleFrequency', 'minorAllele', 'a1a1Count',
+                'a1a2Count', 'a2a2Count', 'noCallCount')
+    }
+}


### PR DESCRIPTION
This ensures that exported data has its colums written in a predictable and logical order

Fixes NAA-81
