### PR TITLE
Retrieve assay columns in the correct order.

### DIFF
--- a/src/groovy/org/transmartproject/db/dataquery/highdim/HighDimensionDataTypeResourceImpl.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/HighDimensionDataTypeResourceImpl.groovy
@@ -71,22 +71,8 @@ class HighDimensionDataTypeResourceImpl implements HighDimensionDataTypeResource
                                  List<DataConstraint> dataConstraints,
                                  Projection projection) {
 
-        // Each module should only return assays that match 
-        // the markertypes specified, in addition to the 
-        // constraints given
-        assayConstraints << new MarkerTypeConstraint(
-                platformNames: module.platformMarkerTypes)
-                                                                  
-        def assayQuery = new AssayQuery(assayConstraints)
-        List<AssayColumn> assays
+        List<AssayColumn> assays = retrieveAssays(assayConstraints)
 
-        assays = assayQuery.retrieveAssays()
-        if (assays.empty) {
-            throw new EmptySetException(
-                    'No assays satisfy the provided criteria')
-        }
-
-        // not needed yet, but it could be a good idea to pass assays here
         HibernateCriteriaBuilder criteriaBuilder =
             module.prepareDataQuery(assays, projection, openSession())
 
@@ -116,6 +102,23 @@ class HighDimensionDataTypeResourceImpl implements HighDimensionDataTypeResource
                 criteriaBuilder.instance.scroll(ScrollMode.FORWARD_ONLY),
                 assays,
                 projection)
+    }
+
+    @Override
+    List<AssayColumn> retrieveAssays(List<AssayConstraint> assayConstraints) {
+        // Each module should only return assays that match
+        // the marker types specified, in addition to the
+        // constraints given
+        assayConstraints << new MarkerTypeConstraint(
+                platformNames: module.platformMarkerTypes)
+
+        def assayQuery = new AssayQuery(assayConstraints)
+        List<AssayColumn> assays = assayQuery.retrieveAssays()
+        if (assays.empty) {
+            throw new EmptySetException(
+                    'No assay satisfies the provided criteria.')
+        }
+        assays
     }
 
     @Override

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/HighDimensionDataTypeResourceImpl.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/HighDimensionDataTypeResourceImpl.groovy
@@ -112,8 +112,7 @@ class HighDimensionDataTypeResourceImpl implements HighDimensionDataTypeResource
         assayConstraints << new MarkerTypeConstraint(
                 platformNames: module.platformMarkerTypes)
 
-        def assayQuery = new AssayQuery(assayConstraints)
-        List<AssayColumn> assays = assayQuery.retrieveAssays()
+        List<AssayColumn> assays = new AssayQuery(assayConstraints).retrieveAssays()
         if (assays.empty) {
             throw new EmptySetException(
                     'No assay satisfies the provided criteria.')

--- a/transmart-core-db-tests/test/integration/org/transmartproject/db/dataquery/highdim/GeneralHighDimensionDataTypeResourceTests.groovy
+++ b/transmart-core-db-tests/test/integration/org/transmartproject/db/dataquery/highdim/GeneralHighDimensionDataTypeResourceTests.groovy
@@ -65,6 +65,12 @@ class GeneralHighDimensionDataTypeResourceTests {
                 testData.assays.sort { it.id }.collect {
                     hasSameInterfaceProperties(Assay, it)
                 })
+
+        def assays = mrnaResource.retrieveAssays([])
+        assertThat assays, contains(
+            testData.assays.sort { it.id }.collect {
+                hasSameInterfaceProperties(Assay, it)
+            })
     }
 
     @Test
@@ -82,6 +88,10 @@ class GeneralHighDimensionDataTypeResourceTests {
         shouldFail EmptySetException, {
             dataQueryResult = mrnaResource.retrieveData(
                     assayConstraints, dataConstraints, projection)
+        }
+
+        shouldFail EmptySetException, {
+            def assays = mrnaResource.retrieveAssays(assayConstraints)
         }
     }
 

--- a/transmart-core-db-tests/test/integration/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzEndToEndRetrievalTest.groovy
+++ b/transmart-core-db-tests/test/integration/org/transmartproject/db/dataquery/highdim/snp_lz/SnpLzEndToEndRetrievalTest.groovy
@@ -196,6 +196,25 @@ class SnpLzEndToEndRetrievalTest {
     }
 
     @Test
+    void retrieveAssaysEqualsIndicesList() {
+        def result = snpLzResource.retrieveData(
+            [trialConstraint], [], allDataProjection)
+        /*
+         * Test if the list of assay ids returning from the query is
+         * the same as in the test data and that the assays are ordered by
+         * assay id.
+         */
+        assert result.indicesList*.id == testData.orderedAssays*.id
+
+        def assays = snpLzResource.retrieveAssays([trialConstraint])
+        /*
+         * Test if retrieveAssays returns the same list as indicesList in the
+         * TabularResult.
+         */
+        assert result.indicesList == assays
+    }
+
+    @Test
     void testIndexingByNumber() {
         result = snpLzResource.retrieveData(
                 [trialConstraint], [], allDataProjection)


### PR DESCRIPTION
A new function has been added to high dimensional
data types that retrieves assay columns in the correct
order.

Related to pull request https://github.com/thehyve/naa-transmart-core-api/pull/3
in transmart-core-api.
