### PR TITLE
Fix NPE when neither tag value nor tag option are present.

### DIFF
--- a/grails-app/domain/org/transmartproject/db/ontology/I2b2Tag.groovy
+++ b/grails-app/domain/org/transmartproject/db/ontology/I2b2Tag.groovy
@@ -36,7 +36,7 @@ class I2b2Tag implements OntologyTermTag {
      * @return the tag value.
      */
     String getDescription() {
-        tag ?: option.value
+        tag ?: option?.value
     }
 
 }


### PR DESCRIPTION
When a tag has no free text data (tag is null) and no
reference to a tag type option, null is returned.
